### PR TITLE
Parser Changes, cd ~, TryLaunch, and echo (Pull Requested)

### DIFF
--- a/WinShell/WinShell/CommandProcessing/CommandProcessor.cs
+++ b/WinShell/WinShell/CommandProcessing/CommandProcessor.cs
@@ -51,11 +51,9 @@ namespace WinShell
         public CommandProcessor(UIManager uiManager)
         {
             UIManager = uiManager;
-            LibManager = new LibraryManager(this);
             Executor = new CommandExecutor(this);
-            Parser = new CommandParser(this);
-
-            LibManager.initLibraries();
+            Parser = new CommandParser(Executor);
+            LibManager = new LibraryManager(Executor);       
         }
 
         /// <summary>

--- a/WinShell/WinShell/CommandProcessing/Commands/BuiltinCommands/BuiltinLibrary.cs
+++ b/WinShell/WinShell/CommandProcessing/Commands/BuiltinCommands/BuiltinLibrary.cs
@@ -21,6 +21,7 @@ namespace WinShell.CommandProcessing.Commands.BuiltinCommands
             new CommandDescriptor { Name = "Cd", Description = "Changes directory. Syntax: cd [absolute/relative path to directory]" },
             new CommandDescriptor { Name = "Dir", Description = "Lists stat call of all directories or files in current directory." },
             new CommandDescriptor { Name = "Pwd", Description = "Prints path to current working directory." },
+            new CommandDescriptor { Name = "Echo", Description = "Prints to the console the parsed arguments that follow this command, if any."},
             new CommandDescriptor { Name = "Exec", Description = "Used to execute a file named identically to a command. Syntax: Exec [filename] [args...]" },
             new CommandDescriptor { Name = "Exit", Description = "Properly close current shell session." },
             new CommandDescriptor { Name = "Cls", Description = "Clear shell display of recent input." },


### PR DESCRIPTION
The following features have been added:
 - 'cd ~' and 'cd ~/[directory]' now replace ~ with the user's home directory using the %HOMEDRIVE%%HOMEPATH%
   environment variable. The '~' is only replaced at the start of the path.
 - 'echo' is now a command, and it can be used to read back the contents of args.
 - Single Quotes now function in the same way as double quotes. These will eventually be strong quotes, while
   double quotes will made into weak quotes.
 - A function TryLaunch has been added the CommandExecutor, and LibraryManager uses it to try executing a file
   with the same name/path as the first element of args when it doesn't match a command or alias name.
 - The empty string is now valid input. No error message is printed, and no crashes occur.

The following other changes have been made:
 - If the user's input contains unclosed outer quotes, an error message is printed and no command is ran.
 - The closing of an outer quote no longer signals the end of a token. This is more in line with how other
   shells handle quotes.
 - The large, ugly If/Else statement in Parser was replaced with a Switch statement using less than ten lines.
   It accomplishes everything the old one did in addition to the new functionality, and it is both easier to
   read and simpler to add onto.
 - The function in CommandParser used to check if a command was valid is no longer needed and has be cut.
 - The execute command and TryLaunch functions now handle the exceptions of CommandExecute's Launch method,
   as they both needed to handle them differently. Any future method calling Launch must also handle any
   exceptions, and this information has been added to its summary for reminder.
 - The only CommandProcessing object that has a pointer to the CommandProcessor is the CommandExecutor. No
   other object should need to interact directly, as the executor is the interface in which to do so.
 - The initLibraries function is now called by LibraryManager's constructor, rather than CommandProcessor.
   I'm not sure what I was thinking when I had kept it out originally, but as of now it makes no sense to
   separate them.

Pull this down and let me know what you think.